### PR TITLE
Rework to fix the autowatch function

### DIFF
--- a/lib/atom-sass.js
+++ b/lib/atom-sass.js
@@ -13,7 +13,7 @@ export default {
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable();
     // Register command that toggles this view
-    console.log("start");
+    console.log("start");   
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'atom-sass:compile': () => this.compile()
     }));

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,60 +1,64 @@
 module.exports = Compiler = (function() {
     function Compiler() {
         var _this           = this;
-        var currentView     = atom.workspace.getActivePaneItem();
-        if(!currentView.getDirectoryPath || !currentView.getPath){
-          return;
-        }
-        this.filePath   = currentView.getPath();
-        this.directoryPath = currentView.getDirectoryPath();
 
-        var saveAction = function( e ){
+        
+        atom.notifications.addSuccess( 'Now watching for Sass files.' );
+        
+        atom.workspace.observeTextEditors(function( item )
+        {
+            var textEditorView = item;
 
-            if ( !currentView['atom-sass-view-modified'] ) {
+            // Incase if we will not get a current view
+            if ( typeof textEditorView === 'undefined' ) {
                 return false;
             }
-            currentView['atom-sass-view-modified'] = false;
 
-            if ( _this.extension === 'scss' || _this.extension === 'sass') {
-                _this.compile( _this.filePath, _this.directoryPath );
+            if(!textEditorView.getDirectoryPath || !textEditorView.getPath){
+              return;
             }
-        };
 
-        if ( typeof currentView === 'undefined' ) {
-
-            atom.notifications.addError( 'Error(1): no file added to watch.' );
-            return false;
-        }
-
-        this.fileName   = currentView.getTitle();
-        this.extension  = this.fileName.split( '.' ).pop();
-        if ( this.extension == 'scss' || this.extension == 'sass' ) {
-
-            this.filePath   = currentView.getPath();
-
-            currentView.onDidChange(function(){
-                currentView['atom-sass-view-modified'] = atom.workspace.getActivePaneItem().isModified();
-            });
-            currentView.onDidSave( saveAction );
-            currentView['atom-sass-activated'] = true;
+            // var fileName = textEditorView.getTitle();
+            // var directoryPath = textEditorView.getDirectoryPath();
+            // var extension = fileName.split( '.' ).pop();
+            // if ( extension === 'scss' || extension === 'sass' ) {
+            // program previously checked if the file had a sass extension before watching it
+            // this is a potental problem as the file could be saved with a different name.
+            // Now, I watch all files and only check extension in onDidSave()
             
-            atom.notifications.addSuccess( 'Now watching file.' );
-        }  else {
-          atom.notifications.addError( 'Error(2): no file added to watch.' );
-        }
+            textEditorView.onDidChangeModified(function(){
+                    textEditorView['atom-sass-view-modified'] = true;
+            });
+            textEditorView.onDidSave( function( e )
+            {						
+                var saveFilePath = e['path'];
+
+                if ( !textEditorView['atom-sass-view-modified'] ) {
+                        return false;
+                }
+                textEditorView['atom-sass-view-modified'] = false;
+                
+                var test = textEditorView.getPath();
+
+                var path = require('path');
+                var extension = path.extname(saveFilePath);
+                if ( extension === '.scss' || extension === '.sass' ) {
+                        _this.compile( saveFilePath );
+                }
+            });
+        });
     }
 
-    Compiler.prototype.compile = function( filePath, directoryPath ) {
+    Compiler.prototype.compile = function( sassFilePath ) {
 
-         var exec = require('child_process').exec,
+        var exec = require('child_process').exec,
             path = require('path');
  
-        var extension = path.basename(filePath).split( '.' ).pop();
-        
-        var fileName = path.basename(filePath).replace('.' + extension, '.css'),
-            outputPath = path.join(directoryPath,fileName);
-
-        var execString = 'sass ' + '"' + filePath + '"' + ' ' + '"' + outputPath +  '"';
+        var extension = path.extname(sassFilePath);
+        var cssFileName = path.win32.basename(sassFilePath).replace(extension, '.css');
+        var cssFilePath = path.join(path.dirname(sassFilePath),cssFileName);
+   
+        var execString = 'sass ' + '"' + sassFilePath + '"' + ' ' + '"' + cssFilePath +  '"';
 
         exec( execString, function (error, stdout, stderr) {
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,7 +15,7 @@ module.exports = Compiler = (function() {
             }
             currentView['atom-sass-view-modified'] = false;
 
-            if ( _this.extension === 'scss' ) {
+            if ( _this.extension === 'scss' || _this.extension === 'sass') {
                 _this.compile( _this.filePath, _this.directoryPath );
             }
         };
@@ -37,7 +37,7 @@ module.exports = Compiler = (function() {
             _this.directoryPath = currentView.getDirectoryPath();
             _this.extension = _this.fileName.split( '.' ).pop();
 
-            if ( _this.extension === 'scss' ) {
+            if ( _this.extension === 'scss' || _this.extension === 'sass') {
                 _this.filePath = currentView.getPath();
                 currentView.onDidSave( saveAction );
                 currentView['atom-sass-activated'] = true;
@@ -51,7 +51,7 @@ module.exports = Compiler = (function() {
 
         this.fileName   = currentView.getTitle();
         this.extension  = this.fileName.split( '.' ).pop();
-        if ( this.extension == 'scss' ) {
+        if ( this.extension == 'scss' || this.extension == 'sass' ) {
 
             this.filePath   = currentView.getPath();
 
@@ -65,12 +65,15 @@ module.exports = Compiler = (function() {
 
     Compiler.prototype.compile = function( filePath, directoryPath ) {
 
-        var exec = require('child_process').exec,
-            path = require('path'),
-            fileName = path.basename(filePath).replace('.scss', '.css'),
+         var exec = require('child_process').exec,
+            path = require('path');
+ 
+        var extension = path.basename(filePath).split( '.' ).pop();
+        
+        var fileName = path.basename(filePath).replace('.' + extension, '.css'),
             outputPath = path.join(directoryPath,fileName);
 
-        var execString = 'sass ' + filePath + ' ' + outputPath;
+        var execString = 'sass ' + '"' + filePath + '"' + ' ' + '"' + outputPath +  '"';
 
         exec( execString, function (error, stdout, stderr) {
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -20,30 +20,6 @@ module.exports = Compiler = (function() {
             }
         };
 
-        atom.workspace.onDidChangeActivePaneItem(function( item ){
-
-            currentView = item;
-
-            // Incase if we will not get a current view
-            if ( typeof currentView === 'undefined' ) {
-                return false;
-            }
-
-            if(!currentView.getDirectoryPath || !currentView.getPath){
-              return;
-            }
-
-            _this.fileName = currentView.getTitle();
-            _this.directoryPath = currentView.getDirectoryPath();
-            _this.extension = _this.fileName.split( '.' ).pop();
-
-            if ( _this.extension === 'scss' || _this.extension === 'sass') {
-                _this.filePath = currentView.getPath();
-                currentView.onDidSave( saveAction );
-                currentView['atom-sass-activated'] = true;
-            }
-        });
-
         if ( typeof currentView === 'undefined' ) {
 
             atom.notifications.addError( 'Error(1): no file added to watch.' );

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,4 +1,5 @@
 var atomSassActivated = false;
+const fs = require('fs');
 
 module.exports = Compiler = (function() {
     function Compiler() {
@@ -48,9 +49,13 @@ module.exports = Compiler = (function() {
             path = require('path');
  
         var extension = path.extname(sassFilePath);
-        var cssFileName = path.win32.basename(sassFilePath).replace(extension, '.css');
+        var cssFileName = path.basename(sassFilePath).replace(extension, '.css');
         var cssFilePath = path.join(path.dirname(sassFilePath),cssFileName);
    
+        fs.access(cssFilePath, fs.constants.F_OK, (err) => {
+            console.log(err ? 'no access!' : 'can read/write');
+        });
+        
         var execString = 'sass ' + '"' + sassFilePath + '"' + ' ' + '"' + cssFilePath +  '"';
 
         exec( execString, function (error, stdout, stderr)

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,52 +1,45 @@
+var atomSassActivated = false;
+
 module.exports = Compiler = (function() {
     function Compiler() {
         var _this           = this;
 
-        
-        atom.notifications.addSuccess( 'Now watching for Sass files.' );
-        
-        atom.workspace.observeTextEditors(function( item )
+        if (atomSassActivated === false)
         {
-            var textEditorView = item;
+            atom.notifications.addSuccess( 'Now watching for Sass files.' );
+            atomSassActivated = true;
+        
+            atom.project.observeBuffers(function( buffer )
+            {
+                var textBuffer = buffer;
 
-            // Incase if we will not get a current view
-            if ( typeof textEditorView === 'undefined' ) {
-                return false;
-            }
+                // there was previously a check for the sass extension before watching a file
+                //  that is possibly a bug a sa file could be saved to a different name.
+                //  now watching all files and doing that check in onSaves call-back
 
-            if(!textEditorView.getDirectoryPath || !textEditorView.getPath){
-              return;
-            }
+                textBuffer.onDidChangeModified(function(){
+                        textBuffer['atom-sass-view-modified'] = true;
+                });
+                textBuffer.onDidSave( function( e )
+                {						
+                    var saveFilePath = e['path'];
 
-            // var fileName = textEditorView.getTitle();
-            // var directoryPath = textEditorView.getDirectoryPath();
-            // var extension = fileName.split( '.' ).pop();
-            // if ( extension === 'scss' || extension === 'sass' ) {
-            // program previously checked if the file had a sass extension before watching it
-            // this is a potental problem as the file could be saved with a different name.
-            // Now, I watch all files and only check extension in onDidSave()
-            
-            textEditorView.onDidChangeModified(function(){
-                    textEditorView['atom-sass-view-modified'] = true;
+                    if ( !textBuffer['atom-sass-view-modified'] ) {
+                            return false;
+                    }
+                    textBuffer['atom-sass-view-modified'] = false;
+
+                    var path = require('path');
+                    var extension = path.extname(saveFilePath);
+                    if ( extension === '.scss' || extension === '.sass' ) {
+                            _this.compile( saveFilePath );
+                    }
+                });
             });
-            textEditorView.onDidSave( function( e )
-            {						
-                var saveFilePath = e['path'];
-
-                if ( !textEditorView['atom-sass-view-modified'] ) {
-                        return false;
-                }
-                textEditorView['atom-sass-view-modified'] = false;
-                
-                var test = textEditorView.getPath();
-
-                var path = require('path');
-                var extension = path.extname(saveFilePath);
-                if ( extension === '.scss' || extension === '.sass' ) {
-                        _this.compile( saveFilePath );
-                }
-            });
-        });
+        } else
+        {
+            atom.notifications.addSuccess( 'Already watching for Sass files.' );
+        }
     }
 
     Compiler.prototype.compile = function( sassFilePath ) {
@@ -60,8 +53,8 @@ module.exports = Compiler = (function() {
    
         var execString = 'sass ' + '"' + sassFilePath + '"' + ' ' + '"' + cssFilePath +  '"';
 
-        exec( execString, function (error, stdout, stderr) {
-
+        exec( execString, function (error, stdout, stderr)
+        {
             if ( error ) {
                 atom.notifications.addError( 'Error while compiling:',{
                     detail: error.message,

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -46,6 +46,7 @@ module.exports = Compiler = (function() {
 
         if ( typeof currentView === 'undefined' ) {
 
+            atom.notifications.addError( 'Error(1): no file added to watch.' );
             return false;
         }
 
@@ -60,6 +61,10 @@ module.exports = Compiler = (function() {
             });
             currentView.onDidSave( saveAction );
             currentView['atom-sass-activated'] = true;
+            
+            atom.notifications.addSuccess( 'Now watching file.' );
+        }  else {
+          atom.notifications.addError( 'Error(2): no file added to watch.' );
         }
     }
 


### PR DESCRIPTION
I originally made a separate branch for this as I changed a lot, but it will only allow me to pull request to the origin/master.
Maybe you can take a look anyway, see if you like the changes.

I wrote descriptions of the changes in the commit messages, I am using atom.project.observeBuffers now to watch for editing of files, the code is simplified so its easy enough to understand.  Only tested on Win7, but nothing that should cause a problem.